### PR TITLE
Remove global i variable and support minification without ng-annotate

### DIFF
--- a/ionic.ion.imagecachefactory.js
+++ b/ionic.ion.imagecachefactory.js
@@ -1,28 +1,29 @@
 angular.module('ionic.ion.imageCacheFactory', [])
 
-.factory("$ImageCacheFactory", function($q,$timeout){
-	return {
-		Cache: function(urls){
-			var promises = [];
-			for(i=0;i<urls.length;i++){
-				var deferred = $q.defer();
-				var img = new Image();
-				img.onload = (function(deferred){
-					return function(){
-						deferred.resolve();
-					}
-				})(deferred);
-				
-				img.onerror = (function(deferred,url){
-					return function(){
-						deferred.reject(url);
-					}
-				})(deferred,urls[i]);
+.factory('$ImageCacheFactory', ['$q', '$timeout', function($q, $timeout) {
+    return {
+        Cache: function(urls) {
+            var promises = [];
+            for (var i = 0; i < urls.length; i++) {
+                var deferred = $q.defer();
+                var img = new Image();
 
-				promises.push(deferred.promise);
-				img.src = urls[i];
-			}
-			return $q.all(promises);
-		}
-	}
-});
+                img.onload = (function(deferred) {
+                    return function(){
+                        deferred.resolve();
+                    }
+                })(deferred);
+                
+                img.onerror = (function(deferred,url) {
+                    return function(){
+                        deferred.reject(url);
+                    }
+                })(deferred,urls[i]);
+
+                promises.push(deferred.promise);
+                img.src = urls[i];
+            }
+            return $q.all(promises);
+        }
+    }
+}]);


### PR DESCRIPTION
Thanks for this nifty service.  I'm now using it in my own app.

I noticed the code has one global variable - 
`for(i=0;i<urls.length;i++){` ---> `for (var i = 0; i < urls.length; i++) {`

I also added support for minification for those not using `ng-annotate`.
